### PR TITLE
Fix package name for Poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [tool.poetry]
-packages = [{include = "llm_foreign_words", from = "src"}]
+packages = [{include = "llm_vocab_agent", from = "src"}]
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- fix the package name in `pyproject.toml` so Poetry installs `llm_vocab_agent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407c673024832092863b6cc2ab6670