### PR TITLE
Update tool invocation to async

### DIFF
--- a/src/llm_vocab_agent/tools.py
+++ b/src/llm_vocab_agent/tools.py
@@ -27,7 +27,7 @@ async def get_verbs(n: int):
 
     chain = prompt | llm.with_structured_output(VerbList) | StrOutputParser()
 
-    result = chain.invoke(input={"n": n})
+    result = await chain.ainvoke(input={"n": n})
 
     return str(result)
 
@@ -46,7 +46,7 @@ async def get_substantiv(n: int):
 
     chain = prompt | llm.with_structured_output(SubstantivList) | StrOutputParser()
 
-    result = chain.invoke(input={"n": n})
+    result = await chain.ainvoke(input={"n": n})
 
     return str(result)
 
@@ -65,7 +65,7 @@ async def get_adjektiv(n: int):
 
     chain = prompt | llm.with_structured_output(AdjektivList) | StrOutputParser()
 
-    result = chain.invoke(input={"n": n})
+    result = await chain.ainvoke(input={"n": n})
 
     return str(result)
 
@@ -84,7 +84,7 @@ async def get_adverb(n: int):
 
     chain = prompt | llm.with_structured_output(AdverbList) | StrOutputParser()
 
-    result = chain.invoke(input={"n": n})
+    result = await chain.ainvoke(input={"n": n})
 
     return str(result)
 


### PR DESCRIPTION
## Summary
- update vocabulary tools to invoke chains asynchronously

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d5a2ea88320a96c7050622acc54