### PR TITLE
Add CSV utility and model tests

### DIFF
--- a/src/llm_vocab_agent/csv_utils.py
+++ b/src/llm_vocab_agent/csv_utils.py
@@ -1,0 +1,15 @@
+import csv
+from typing import Iterable, List
+
+
+def load_words_from_csv(path: str) -> List[str]:
+    """Load words from a CSV file using the ``word`` column."""
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        return [row['word'] for row in reader if row.get('word')]
+
+
+def filter_known_words(words: Iterable[str], known_words: Iterable[str]) -> List[str]:
+    """Return words not present in the collection of known words."""
+    known_set = {w.lower() for w in known_words}
+    return [w for w in words if w.lower() not in known_set]

--- a/src/llm_vocab_agent/models/substantiv.py
+++ b/src/llm_vocab_agent/models/substantiv.py
@@ -30,10 +30,11 @@ class Substantiv(BaseModel):
     )
 
     def __str__(self):
+        examples = "\n\t".join(self.example)
         return (
             f"# {self.word} - {self.translate}, {self.genetiv}, {self.plural}"
             f"\n\t{self.gender.value}, {self.level}"
-            f"\n\t{"\n\t".join(self.example)}\n\t{self.note}"
+            f"\n\t{examples}\n\t{self.note}"
         )
 
 

--- a/src/llm_vocab_agent/models/verb.py
+++ b/src/llm_vocab_agent/models/verb.py
@@ -43,10 +43,12 @@ class Verb(BaseModel):
     )
 
     def __str__(self):
+        rektion = f" {self.rektion}" if self.rektion else ""
+        note = f"\n## {self.note}" if self.note else ""
         return (
-            f"# {self.word}{" " + f"{self.rektion}" if self.rektion is not None else ""} - {self.translate}"
+            f"# {self.word}{rektion} - {self.translate}"
             f" - {self.prateritum} - {self.partizip_ii}"
-            f"{((f"\n## {self.note}") if self.note is not None else "")}"
+            f"{note}"
         )
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure the src directory is on the path for test imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,0 +1,18 @@
+import csv
+from llm_vocab_agent.csv_utils import load_words_from_csv, filter_known_words
+
+
+def test_load_words_from_csv(tmp_path):
+    csv_path = tmp_path / "words.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["word", "translate"])
+        writer.writeheader()
+        writer.writerow({"word": "sagen", "translate": "говорить"})
+        writer.writerow({"word": "gehen", "translate": "идти"})
+    assert load_words_from_csv(csv_path) == ["sagen", "gehen"]
+
+
+def test_filter_known_words():
+    words = ["sagen", "gehen", "machen"]
+    known = ["gehen"]
+    assert filter_known_words(words, known) == ["sagen", "machen"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,75 @@
+from llm_vocab_agent.models import (
+    Verb,
+    VerbList,
+    Substantiv,
+    SubstantivList,
+    Adjektiv,
+    AdjektivList,
+    Adverb,
+    AdverbList,
+)
+from llm_vocab_agent.models.verb import VerbType, VerbAUX
+from llm_vocab_agent.models.substantiv import Gender
+
+
+def test_verb_list_str():
+    verbs = [
+        Verb(
+            word="machen",
+            translate="делать",
+            level="A1",
+            verb_type=VerbType.regelmassig,
+            aux=VerbAUX.haben,
+            presens_3st="macht",
+            prateritum="machte",
+            partizip_ii="hat gemacht",
+            reaktion="",
+            note=None,
+        ),
+        Verb(
+            word="gehen",
+            translate="идти",
+            level="A1",
+            verb_type=VerbType.unregelmassig,
+            aux=VerbAUX.sein,
+            presens_3st="geht",
+            prateritum="ging",
+            partizip_ii="ist gegangen",
+            reaktion="",
+            note=None,
+        ),
+    ]
+    out = str(VerbList(verbs=verbs))
+    assert "# machen" in out
+    assert "# gehen" in out
+
+
+def test_substantiv_list_str():
+    subs = [
+        Substantiv(
+            gender=Gender.maskuline,
+            level="A1",
+            word="der Mann",
+            translate="мужчина",
+            genetiv="des Mannes",
+            plural="die Männer",
+            example=["der Mann kommt"],
+            note="",
+        )
+    ]
+    out = str(SubstantivList(substantiven=subs))
+    assert "der Mann" in out
+
+
+def test_adjektiv_list_str():
+    adjs = [
+        Adjektiv(word="klein", translate="маленький", examples=["ein kleines Haus"])
+    ]
+    out = str(AdjektivList(adjektivs=adjs))
+    assert "klein - маленький" in out
+
+
+def test_adverb_list_str():
+    advs = [Adverb(word="schnell", translate="быстро", examples=["er rennt schnell"])]
+    out = str(AdverbList(adverbs=advs))
+    assert "schnell - быстро" in out


### PR DESCRIPTION
## Summary
- add csv_utils helper with parsing/filtering helpers
- fix `__str__` methods in `Verb` and `Substantiv`
- add tests for csv utils and output of models
- ensure tests can import package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407d5eb14c8320becd0155f72b3844